### PR TITLE
Fixes #2

### DIFF
--- a/trixnity-core/src/commonMain/kotlin/net/folivo/trixnity/core/model/events/m/room/MessageEventContent.kt
+++ b/trixnity-core/src/commonMain/kotlin/net/folivo/trixnity/core/model/events/m/room/MessageEventContent.kt
@@ -42,8 +42,8 @@ sealed class MessageEventContent : RoomEventContent {
 
     @Serializable
     data class UnknownMessageEventContent(
-        @SerialName("msgtype") val type: String,
-        @SerialName("body") override val body: String
+        @SerialName("msgtype") val type: String? = null,
+        @SerialName("body") override val body: String = ""
     ) : MessageEventContent()
 }
 

--- a/trixnity-core/src/commonMain/kotlin/net/folivo/trixnity/core/model/events/m/room/RedactionEventContent.kt
+++ b/trixnity-core/src/commonMain/kotlin/net/folivo/trixnity/core/model/events/m/room/RedactionEventContent.kt
@@ -11,7 +11,7 @@ import net.folivo.trixnity.core.model.events.RoomEventContent
 @Serializable
 data class RedactionEventContent(
     @SerialName("reason")
-    val reason: String?,
+    val reason: String? = null,
     @SerialName("redacts")
     val redacts: MatrixId.EventId
 ) : RoomEventContent


### PR DESCRIPTION
This should fix #2 - kotlinx.serialization requires a default value if the value should be inferred when missing in JSON. You should probably write tests for this bug